### PR TITLE
Make it work in Powershell

### DIFF
--- a/autoload/sql/query.vim
+++ b/autoload/sql/query.vim
@@ -48,7 +48,7 @@ function! s:commandLine(platform, server, database, type, action, actionValues) 
 endfunction
 
 function! s:formatArgString(args, actionValues={}) abort " {{{1
-    let args = filter(a:args,{k,_ -> k != 'order'})
+    let args = filter(copy(a:args),{k,_ -> k != 'order'})
 
     for k in keys(args)
         let parm = matchstr(args[k], '<\w\{-}>')

--- a/autoload/sql/query.vim
+++ b/autoload/sql/query.vim
@@ -56,7 +56,7 @@ function! s:formatArgString(args, actionValues={}) abort " {{{1
             continue
         endif
         if has_key(a:actionValues, parm[1:-2])
-            let args[k] = substitute(args[k], parm, get(a:actionValues, parm[1:-2], ''), 'g')
+            let args[k] = substitute(args[k], parm, a:actionValues[parm[1:-2]], 'g')
             continue
         endif
         call remove(args, k)

--- a/autoload/sql/query.vim
+++ b/autoload/sql/query.vim
@@ -44,7 +44,7 @@ function! s:commandLine(platform, server, database, type, action, actionValues) 
 
     let parm = matchstr(cmdline, '<\w\{-}>')
     while parm != ''
-        let cmdline = substitute(cmdline, parm, get(a:actionValues, parm[1:-2], ''), '')
+        let cmdline = substitute(cmdline, parm, get(a:actionValues, parm[1:-2], '-'), '')
         let parm = matchstr(cmdline, '<\w\{-}>')
     endwhile
 

--- a/autoload/sql/query.vim
+++ b/autoload/sql/query.vim
@@ -30,12 +30,12 @@ endfunction
 
 function! s:commandLine(platform, server, database, type, action, actionValues) abort " {{{1
     let actionValues = {
-        \ 'file': escape(empty(a:action) ?
+        \ 'file':      escape(empty(a:action) ?
             \ sql#settings#tempFile() :
-            \ sql#settings#root().'\'.a:platform.'\'.sql#settings#app()[a:platform].actions[a:type][a:action], '\'),
-        \ 'server':escape(a:server,'\'),
-        \ 'database':escape(a:database,'\'),
-        \ 'delimiter':sql#settings#delimiter(a:platform)
+            \ printf('%s\%s\%s', sql#settings#root(), a:platform, sql#settings#app()[a:platform].actions[a:type][a:action]), '\'),
+        \ 'server':    escape(a:server,'\'),
+        \ 'database':  escape(a:database,'\'),
+        \ 'delimiter': sql#settings#delimiter(a:platform)
     \ }
     let actionValues = extend(a:actionValues, actionValues, 'force')
 
@@ -62,5 +62,5 @@ function! s:formatArgString(args, actionValues={}) abort " {{{1
         call remove(args, k)
     endfor
 
-    return  join(values(map(args, {k,v -> v==v:null ? k : k.' '.v})), ' ')
+    return join(values(map(args, {k, v -> v == v:null ? k : k.' '.v})), ' ')
 endfunction

--- a/autoload/sql/query.vim
+++ b/autoload/sql/query.vim
@@ -29,28 +29,38 @@ function! s:on_exit(job_id, data, event) " {{{1
 endfunction
 
 function! s:commandLine(platform, server, database, type, action, actionValues) abort " {{{1
+    let actionValues = {
+        \ 'file': escape(empty(a:action) ?
+            \ sql#settings#tempFile() :
+            \ sql#settings#root().'\'.a:platform.'\'.sql#settings#app()[a:platform].actions[a:type][a:action], '\'),
+        \ 'server':escape(a:server,'\'),
+        \ 'database':escape(a:database,'\'),
+        \ 'delimiter':sql#settings#delimiter(a:platform)
+    \ }
+    let actionValues = extend(a:actionValues, actionValues, 'force')
+
     let cmdline = sql#settings#app()[a:platform].executable
-    let cmdline .= ' '.s:formatArgString(sql#settings#app()[a:platform].args)
-    let cmdline .= ' '.s:formatArgString(sql#settings#serverInfo(a:platform,a:server))
-    let cmdline .= empty(a:action) ? '' : ' '.s:formatArgString(sql#settings#app()[a:platform].actions.args)
-
-    let file = empty(a:action) ?
-          \ sql#settings#tempFile() :
-          \ sql#settings#root().'\'.a:platform.'\'.sql#settings#app()[a:platform].actions[a:type][a:action]
-    let cmdline = substitute(cmdline, '<file>', escape(file, '\'), '')
-    let cmdline = substitute(cmdline, '<server>', escape(a:server, '\'), '')
-    let cmdline = substitute(cmdline, '<database>', a:database, '')
-    let cmdline = substitute(cmdline, '<delimiter>', sql#settings#delimiter(a:platform), '')
-
-    let parm = matchstr(cmdline, '<\w\{-}>')
-    while parm != ''
-        let cmdline = substitute(cmdline, parm, get(a:actionValues, parm[1:-2], '-'), '')
-        let parm = matchstr(cmdline, '<\w\{-}>')
-    endwhile
+    let cmdline .= ' '.s:formatArgString(sql#settings#app()[a:platform].args, actionValues)
+    let cmdline .= ' '.s:formatArgString(sql#settings#serverInfo(a:platform,a:server), actionValues)
+    let cmdline .= empty(a:action) ? '' : ' '.s:formatArgString(sql#settings#app()[a:platform].actions.args, actionValues)
 
     return cmdline
 endfunction
 
-function! s:formatArgString(args) abort " {{{1
-    return join(map(filter(keys(a:args),{_,v -> v != 'order'}), {_,v -> v.' '.(a:args[v]==v:null ? '' : a:args[v])}), ' ')
+function! s:formatArgString(args, actionValues={}) abort " {{{1
+    let args = filter(a:args,{k,_ -> k != 'order'})
+
+    for k in keys(args)
+        let parm = matchstr(args[k], '<\w\{-}>')
+        if empty(parm)
+            continue
+        endif
+        if has_key(a:actionValues, parm[1:-2])
+            let args[k] = substitute(args[k], parm, get(a:actionValues, parm[1:-2], ''), 'g')
+            continue
+        endif
+        call remove(args, k)
+    endfor
+
+    return  join(values(map(args, {k,v -> v==v:null ? k : k.' '.v})), ' ')
 endfunction


### PR DESCRIPTION
## Author's Comments

This PR enables the plugin to work with `:shell=pwsh`, and probably `powershell` too. An error would occur when getting the list of databases from the server; the command line included this text: `-v object=""`. `:set shell=cmd.exe` handles it just fine, but with `:set shell=pwsh` you would get the following error:
```
Sqlcmd: 'object=': Invalid argument. Enter '-?' for help.
```

The other options that need to be set are:
```lua
vim.o.shell = 'pwsh'
vim.o.shellcmdflag = '-NoLogo -NonInteractive -ExecutionPolicy RemoteSigned -Command'
vim.o.shellquote = '"'
vim.o.shellxquote = ''
```
---
## Copilot's Comments

This pull request refactors how command line arguments are constructed and substituted for SQL queries, making the process more flexible and easier to maintain. The main change is the introduction of an `actionValues` dictionary for parameter substitution and updating the argument formatting logic to handle dynamic values more robustly.

**Improvements to argument substitution and command line construction:**

* Refactored `s:commandLine` to build an `actionValues` dictionary containing all relevant parameters (file, server, database, delimiter), and merged it with any user-supplied values for flexible substitution.
* Updated the way command line arguments are formatted by passing `actionValues` to `s:formatArgString`, enabling dynamic replacement of placeholders within argument strings.
* Enhanced `s:formatArgString` to iterate over argument keys, substitute placeholders with values from `actionValues`, and remove arguments without valid substitutions, resulting in cleaner and more accurate command lines.
